### PR TITLE
Handle no reposync data gracefully

### DIFF
--- a/health-check/mgr-health-check.changes.mczernek.crash_no_repo_logs
+++ b/health-check/mgr-health-check.changes.mczernek.crash_no_repo_logs
@@ -1,0 +1,1 @@
+- Handle gracefully lack of reposync logs

--- a/health-check/src/health_check/exporters/supportconfig_exporter.py
+++ b/health-check/src/health_check/exporters/supportconfig_exporter.py
@@ -509,6 +509,11 @@ class SupportConfigMetricsCollector:
         log_files = sorted(
             reposync_log_path.iterdir(), key=os.path.getmtime, reverse=True
         )
+
+        if len(log_files) == 0:
+            # no reposync logs
+            return
+
         most_recent_mtime = os.path.getmtime(log_files[0])
         one_day_seconds = 86400
 


### PR DESCRIPTION
When analyzing supportconfig with no reposync data, exporter fails to start due to the following error:

```
upportconfig Exporter started
Traceback (most recent call last):
  File "/opt/supportconfig_exporter.py", line 572, in <module>
    main()
  File "/opt/supportconfig_exporter.py", line 564, in main
    collector = SupportConfigMetricsCollector(supportconfig_path)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/supportconfig_exporter.py", line 72, in __init__
    self.parse()
  File "/opt/supportconfig_exporter.py", line 84, in parse
    self.parse_num_of_channels()
  File "/opt/supportconfig_exporter.py", line 512, in parse_num_of_channels
    most_recent_mtime = os.path.getmtime(log_files[0])
                                         ~~~~~~~~~^^^
IndexError: list index out of range
```

This PR fixes the error and enables the exporter container to start.