### PR TITLE
Adapt metric collection for 5.1 and recent supportconfig version

### DIFF
--- a/health-check/mgr-health-check.changes.meaksh.master-issues-in-5.1
+++ b/health-check/mgr-health-check.changes.meaksh.master-issues-in-5.1
@@ -1,0 +1,4 @@
+- Enhance server version metric to work with version 5.1
+- Make logging messages to appear in container logs
+- Collect apache metrics properly in latest supportconfigs
+- Set num_of_channels metric to zero when no channels are found

--- a/health-check/src/health_check/config/templates/grafana_dashboard/supportconfig_with_logs.template.json
+++ b/health-check/src/health_check/config/templates/grafana_dashboard/supportconfig_with_logs.template.json
@@ -1084,7 +1084,7 @@
           "global_query_id": "",
           "parser": "backend",
           "refId": "A",
-          "root_selector": "misc[name = \"major_version\"]",
+          "root_selector": "misc[name = \"version\"]",
           "source": "url",
           "type": "json",
           "url": "http://health_check_supportconfig_exporter:9000/metrics.json",
@@ -1094,7 +1094,7 @@
           }
         }
       ],
-      "title": "Server major version",
+      "title": "Server version",
       "transformations": [
         {
           "id": "convertFieldType",
@@ -1302,13 +1302,13 @@
         {
           "columns": [],
           "computed_columns": [],
-          "filterExpression": "(name == \"master\" || name == \"proxy\" || name == \"client\") && value == 1",
+          "filterExpression": "value == 1",
           "filters": [],
           "format": "table",
           "global_query_id": "",
           "parser": "backend",
           "refId": "A",
-          "root_selector": "misc",
+          "root_selector": "misc[name='proxy' or name='master' or name='client']",
           "source": "url",
           "type": "json",
           "url": "http://health_check_supportconfig_exporter:9000/metrics.json",

--- a/health-check/src/health_check/exporters/static_metrics.py
+++ b/health-check/src/health_check/exporters/static_metrics.py
@@ -105,9 +105,9 @@ metrics_config = {
         "pattern": r"Swap:\s+\d+\s+\d+\s+(\d+)",
         "label": "memory",
     },
-    "major_version": {
+    "version": {
         "filepath": "basic-environment.txt",
-        "pattern": r"^SUSE Manager release (\d)",
+        "pattern": r"(?:^SUSE Manager release ([\d.]+)|^SUSE Multi-Linux Manager release [\d.]+ \(([\d\w.\ ]+)\))",
         "label": "misc",
     },
 }
@@ -159,6 +159,8 @@ class LogFileStaticMetric(StaticMetric):
                     return int(xmx_value) * 1024
                 if xmx_unit == "g" or xmx_unit == "G":
                     return int(xmx_value) * 1024 * 1024
+            elif self.name == "version":
+                return match.group(1) or match.group(2)
             else:
                 return int(match.group(1))
 

--- a/health-check/src/health_check/exporters/static_metrics.py
+++ b/health-check/src/health_check/exporters/static_metrics.py
@@ -107,8 +107,16 @@ metrics_config = {
     },
     "version": {
         "filepath": "basic-environment.txt",
-        "pattern": r"(?:^SUSE Manager release ([\d.]+)|^SUSE Multi-Linux Manager release [\d.]+ \(([\d\w.\ ]+)\))",
+        # This pattern matches and extract the appropiated version
+        # from the following supported releases file content:
+        #
+        # - SUSE Manager release 4.3 (2025.05)
+        # - SUSE Multi-Linux Manager release 5.1 (5.1.0 RC)
+        # - Uyuni release 2025.05
+        #
+        "pattern": r"^(?:SUSE (?:Manager release ([\d.]+)|Multi-Linux Manager release [\d.]+ \(([\d\w.\ ]+)\))|Uyuni release ([\d.]+))",
         "label": "misc",
+        "default": "unknown",
     },
 }
 
@@ -160,7 +168,7 @@ class LogFileStaticMetric(StaticMetric):
                 if xmx_unit == "g" or xmx_unit == "G":
                     return int(xmx_value) * 1024 * 1024
             elif self.name == "version":
-                return match.group(1) or match.group(2)
+                return match.group(1) or match.group(2) or match.group(3)
             else:
                 return int(match.group(1))
 

--- a/health-check/src/health_check/exporters/static_metrics.py
+++ b/health-check/src/health_check/exporters/static_metrics.py
@@ -114,7 +114,7 @@ metrics_config = {
         # - SUSE Multi-Linux Manager release 5.1 (5.1.0 RC)
         # - Uyuni release 2025.05
         #
-        "pattern": r"^(?:SUSE (?:Manager release ([\d.]+)|Multi-Linux Manager release [\d.]+ \(([\d\w.\ ]+)\))|Uyuni release ([\d.]+))",
+        "pattern": r"^(?:SUSE (?:Manager release (?P<suma_release>[\d.]+)|Multi-Linux Manager release [\d.]+ \((?P<smlm_release>[\d\w.\ ]+)\))|Uyuni release (?P<uyuni_release>[\d.]+))$",
         "label": "misc",
         "default": "unknown",
     },
@@ -168,7 +168,7 @@ class LogFileStaticMetric(StaticMetric):
                 if xmx_unit == "g" or xmx_unit == "G":
                     return int(xmx_value) * 1024 * 1024
             elif self.name == "version":
-                return match.group(1) or match.group(2) or match.group(3)
+                return match.group("suma_release") or match.group("smlm_release") or match.group("uyuni_release")
             else:
                 return int(match.group(1))
 

--- a/health-check/src/health_check/exporters/static_metrics.py
+++ b/health-check/src/health_check/exporters/static_metrics.py
@@ -168,7 +168,11 @@ class LogFileStaticMetric(StaticMetric):
                 if xmx_unit == "g" or xmx_unit == "G":
                     return int(xmx_value) * 1024 * 1024
             elif self.name == "version":
-                return match.group("suma_release") or match.group("smlm_release") or match.group("uyuni_release")
+                return (
+                    match.group("suma_release")
+                    or match.group("smlm_release")
+                    or match.group("uyuni_release")
+                )
             else:
                 return int(match.group(1))
 

--- a/health-check/src/health_check/exporters/supportconfig_exporter.py
+++ b/health-check/src/health_check/exporters/supportconfig_exporter.py
@@ -52,7 +52,7 @@ class SupportConfigMetricsCollector:
         self.server_limit = -1
         self.num_of_channels = -1
         self.shared_buffers_to_mem_ratio = -1
-        self.major_version = -1
+        self.version = ""
         self.fs_mount_insufficient = -1
         self.fs_mount_out_of_space = -1
         self.roles = [
@@ -333,7 +333,9 @@ class SupportConfigMetricsCollector:
         role = role.pop()["name"]
 
         paths = (
-            self._gen_mounts_for_checking().get(self.major_version, {}).get(role, {})
+            self._gen_mounts_for_checking()
+            .get(int(self.version.split(".")[0]), {})
+            .get(role, {})
         )
         if not paths:
             print("Cannot determine filesystem requirements")

--- a/health-check/src/health_check/exporters/supportconfig_exporter.py
+++ b/health-check/src/health_check/exporters/supportconfig_exporter.py
@@ -146,7 +146,7 @@ class SupportConfigMetricsCollector:
             content = f.read()
             # Parse contents of server-tuning.conf first
             file_regex = (
-                r"(?s)/etc/apache2/server-tuning.conf(.*?)\[ Configuration File \]"
+                r"(?s)# /etc/apache2/server-tuning.conf(.*?)\[ Configuration File \]"
             )
             # Then, parse the MaxRequestWorkers property from the prefork part
             max_req_regex = r"(?s)<IfModule prefork\.c>(.*?)MaxRequestWorkers\s+(\d+)$"

--- a/health-check/src/health_check/exporters/supportconfig_exporter.py
+++ b/health-check/src/health_check/exporters/supportconfig_exporter.py
@@ -512,11 +512,13 @@ class SupportConfigMetricsCollector:
         Approximate the number of active channels by counting reposync log files modified within 24h
         of the most recently modified file.
         """
+        self.num_of_channels = 0
         reposync_log_path = Path(
             f"{self.supportconfig_path}/spacewalk-debug/rhn-logs/rhn/reposync"
         )
         if not reposync_log_path.exists():
             return
+
         log_files = sorted(
             reposync_log_path.iterdir(), key=os.path.getmtime, reverse=True
         )

--- a/health-check/src/health_check/exporters/supportconfig_exporter.py
+++ b/health-check/src/health_check/exporters/supportconfig_exporter.py
@@ -344,11 +344,12 @@ class SupportConfigMetricsCollector:
             return
         role = role.pop()["name"]
 
-        paths = (
-            self._gen_mounts_for_checking()
-            .get(int(self.version.split(".", maxsplit=1)[0]), {})
-            .get(role, {})
-        )
+        try:
+            major_version = int(self.version.split(".", maxsplit=1)[0])
+        except ValueError:
+            major_version = None
+
+        paths = self._gen_mounts_for_checking().get(major_version, {}).get(role, {})
         if not paths:
             log.error("Cannot determine filesystem requirements")
             return

--- a/health-check/src/health_check/exporters/supportconfig_exporter.py
+++ b/health-check/src/health_check/exporters/supportconfig_exporter.py
@@ -116,7 +116,8 @@ class SupportConfigMetricsCollector:
 
             if not shared_buffers.isnumeric():
                 log.error(
-                    f"Error when parsing shared_buffers; expected int, got: {shared_buffers}"
+                    "Error when parsing shared_buffers; expected int, got: %s",
+                    shared_buffers,
                 )
                 return
 
@@ -130,7 +131,7 @@ class SupportConfigMetricsCollector:
             elif buffer_unit == "gb":
                 shared_buffers *= 1024 * 1024
             else:
-                log.error(f"Error when parsing shared buffer unit: {buffer_unit}")
+                log.error("Error when parsing shared buffer unit: %s", buffer_unit)
                 return
 
             self.shared_buffers_to_mem_ratio = round(shared_buffers / memory, 2)
@@ -170,7 +171,8 @@ class SupportConfigMetricsCollector:
                     self.max_clients = int(max_clients)
                 except ValueError:
                     log.error(
-                        f"Error when parsing max_clients; expected int, got: {max_clients}"
+                        "Error when parsing max_clients; expected int, got: %s",
+                        max_clients,
                     )
 
             if server_lim_match:
@@ -179,7 +181,8 @@ class SupportConfigMetricsCollector:
                     self.server_limit = int(server_limit)
                 except ValueError:
                     log.error(
-                        f"Error when parsing ServerLimit; expected int, got: {server_limit}"
+                        "Error when parsing ServerLimit; expected int, got: %s",
+                        server_limit,
                     )
 
     def parse_roles(self):
@@ -250,7 +253,7 @@ class SupportConfigMetricsCollector:
         elif unit == "n/a":
             ...  # no unit
         else:
-            log.error(f"Error when parsing shared buffer unit: {unit}")
+            log.error("Error when parsing shared buffer unit: %s", unit)
 
         res["too_small"] = 1 if min_size_gb > size else 0
         return res
@@ -343,7 +346,7 @@ class SupportConfigMetricsCollector:
 
         paths = (
             self._gen_mounts_for_checking()
-            .get(int(self.version.split(".")[0]), {})
+            .get(int(self.version.split(".", maxsplit=1)[0]), {})
             .get(role, {})
         )
         if not paths:
@@ -358,7 +361,7 @@ class SupportConfigMetricsCollector:
             )
             fs_obj = self._check_vol_params(mount, path.min_size_gb, fs)
             if not fs_obj:
-                log.error(f"Could not find {mount}")
+                log.error("Could not find %s", mount)
                 continue
             mounts[fs_obj["mount"]].append(fs_obj)
 
@@ -571,7 +574,7 @@ class Handler(http.server.SimpleHTTPRequestHandler):
 def main():
     log.info("Supportconfig Exporter started")
     if not os.path.exists(SUPPORTCONFIG_ETC_CONFIG):
-        log.error(f"Could not find {SUPPORTCONFIG_ETC_CONFIG}")
+        log.error("Could not find %s", SUPPORTCONFIG_ETC_CONFIG)
         exit(1)
 
     with open(SUPPORTCONFIG_ETC_CONFIG, "r", encoding="UTF-8") as config_file:
@@ -582,7 +585,7 @@ def main():
     collector = SupportConfigMetricsCollector(supportconfig_path)
     collector.write_metrics()
     with http.server.ThreadingHTTPServer(("", port), Handler) as httpd:
-        log.info(f"serving at port {port}")
+        log.info("serving at port %s", port)
         httpd.serve_forever()
 
 


### PR DESCRIPTION
As title says, this PR simply adapt supportconfig exporter to properly fetch metrics on 5.1 environment.

Additionally, it fixes some other issues:
- Make logging messages to appear in container logs
- Collect apache metrics properly in latest supportconfigs
- Set num_of_channels metric to zero when no channels are found

These changes are tested against 4.3, 5.0 and 5.1 generated supportconfigs.