### PR TITLE
Ask for user confirmation when "spacewalk-debug" is missing in the provided supportconfig

### DIFF
--- a/health-check/mgr-health-check.changes.meaksh.master-ask-confirmation-when-no-spacewalk-debug
+++ b/health-check/mgr-health-check.changes.meaksh.master-ask-confirmation-when-no-spacewalk-debug
@@ -1,0 +1,2 @@
+- Ask for user confirmation in case spacewalk-debug
+  is missing in the supportconfig

--- a/health-check/src/health_check/main.py
+++ b/health-check/src/health_check/main.py
@@ -6,6 +6,7 @@ import click
 from rich.markdown import Markdown
 from rich.panel import Panel
 from rich.text import Text
+from rich.prompt import Confirm
 
 import health_check.config as config
 import health_check.utils as utils
@@ -88,6 +89,13 @@ def start(ctx: click.Context, from_datetime: str, to_datetime: str, since: int):
             "[red bold]A valid supportconfig cannot be found in the provided path, exitting"
         )
         exit(1)
+
+    if not os.path.exists(os.path.join(supportconfig_path, "spacewalk-debug")):
+        console.log(
+            "[red bold]The provided supportconfig seems not generated inside an Uyuni or SUSE Multi-Linux Manager server. Some metrics might be missing."
+        )
+        if not Confirm.ask("Do you want to continue anyway?", default=False):
+            exit(1)
 
     period_start, period_end = utils.get_dates(since)
 


### PR DESCRIPTION
This PR asks the user for a confirmation to start the execution in cases where a valid supportconfig does not contain a "spacewalk-debug" directory, meaning it is not coming from an Uyuni / MLM server and therefore metrics are going to be missing in the Grafana dashboard.

Passing a "supportconfig" which is not containing a "spacewalk-debug" is actually a valid case, i.a. when supportconfig is coming from a proxy or a client, but lot of the metrics won't appear in the current dashboard (as it is still mostly focused on showing metrics from a Uyuni / MLM server)