### PR TITLE
Fix server version regex

### DIFF
--- a/health-check/src/health_check/exporters/static_metrics.py
+++ b/health-check/src/health_check/exporters/static_metrics.py
@@ -114,7 +114,7 @@ metrics_config = {
         # - SUSE Multi-Linux Manager release 5.1 (5.1.0 RC)
         # - Uyuni release 2025.05
         #
-        "pattern": r"^(?:SUSE (?:Manager release (?P<suma_release>[\d.]+)|Multi-Linux Manager release [\d.]+ \((?P<smlm_release>[\d\w.\ ]+)\))|Uyuni release (?P<uyuni_release>[\d.]+))$",
+        "pattern": r"^(?:SUSE (?:Manager release (?P<suma_release>[\d.]+).*|Multi-Linux Manager release [\d.]+ \((?P<smlm_release>[\d\w.\ ]+)\))|Uyuni release (?P<uyuni_release>[\d.]+))$",
         "label": "misc",
         "default": "unknown",
     },


### PR DESCRIPTION
Currently, our regex does not match the supported `SUSE Manager release 4.3 (2025.05)` pattern, because anything after the `4.3` is not matched, and the regex matches end of line.

This is a quick fix to the regex.