### PR TITLE
Fix container building in OBS

### DIFF
--- a/containers/health-check-supportconfig-exporter-image/Dockerfile
+++ b/containers/health-check-supportconfig-exporter-image/Dockerfile
@@ -29,7 +29,8 @@ LABEL org.opensuse.reference="${REFERENCE_PREFIX}/health-check-supportconfig-exp
 # endlabelprefix
 LABEL org.uyuni.version="${PRODUCT_VERSION}"
 
-COPY static_metrics.py supportconfig_exporter.py /opt/
+COPY supportconfig_exporter.py /opt/
+COPY static_metrics.py /opt/
 
 WORKDIR /opt/
 ENTRYPOINT ["python3.11", "/opt/supportconfig_exporter.py"]


### PR DESCRIPTION
For some reason, in OBS, when using the `COPY $file1 $file2 ... $dest` syntax, the copied files are not present in the resulting container.

When using the `COPY $file $dst` syntax, this works as expected.

Tested in [0], you can download and verify the built image with [1].

[0] https://build.opensuse.org/package/show/home:mczernek:branches:systemsmanagement:Uyuni:healthcheck/health-check-supportconfig-exporter-image
[1] `podman run --rm -it --entrypoint bash registry.opensuse.org/home/mczernek/branches/systemsmanagement/uyuni/healthcheck/containers/uyuni/health-check-supportconfig-exporter:latest`