### PR TITLE
Do not bind to all interfaces by default

### DIFF
--- a/health-check/mgr-health-check.changes.mczernek.iface-binding
+++ b/health-check/mgr-health-check.changes.mczernek.iface-binding
@@ -1,0 +1,1 @@
+- Do not bind ports on all ifaces by default

--- a/health-check/src/health_check/exporters/exporter.py
+++ b/health-check/src/health_check/exporters/exporter.py
@@ -5,7 +5,7 @@ from health_check.containers.manager import container_is_running, podman
 from health_check.utils import console
 
 
-def prepare_exporter(supportconfig_path: str, verbose: bool):
+def prepare_exporter(supportconfig_path: str, verbose: bool, iface="127.0.0.1"):
     """
     Build the exporter image and deploy it on the server
 
@@ -30,7 +30,7 @@ def prepare_exporter(supportconfig_path: str, verbose: bool):
         "--network",
         config.load_prop("podman.network_name"),
         "--publish",
-        "9000:9000",
+        f"{iface}:9000:9000",
         "--volume",
         f"{supportconfig_path}:{supportconfig_path}",
         "--volume",

--- a/health-check/src/health_check/grafana/grafana_manager.py
+++ b/health-check/src/health_check/grafana/grafana_manager.py
@@ -7,7 +7,9 @@ from health_check.containers.manager import container_is_running, podman
 from health_check.utils import console
 
 
-def prepare_grafana(from_datetime: str, to_datetime: str, verbose: bool):
+def prepare_grafana(
+    from_datetime: str, to_datetime: str, verbose: bool, iface="127.0.0.1"
+):
     name = config.load_prop("grafana.container_name")
     image = config.load_prop("grafana.image")
     console.log("[bold]Deploying Grafana")
@@ -34,7 +36,7 @@ def prepare_grafana(from_datetime: str, to_datetime: str, verbose: bool):
             "--network",
             config.load_prop("podman.network_name"),
             "--publish",
-            "3000:3000",
+            f"{iface}:3000:3000",
             "--volume",
             f"{grafana_cfg}/alerts.yaml:/etc/grafana/provisioning/alerting/alerts.yaml",
             "--volume",

--- a/health-check/src/health_check/loki/loki_manager.py
+++ b/health-check/src/health_check/loki/loki_manager.py
@@ -13,7 +13,7 @@ PROMTAIL_TARGETS = 6
 LOKI_WAIT_TIMEOUT = 120
 
 
-def run_loki(supportconfig_path=None, verbose=False):
+def run_loki(supportconfig_path=None, verbose=False, iface="127.0.0.1"):
     """
     Run promtail and loki to aggregate the logs
     """
@@ -38,7 +38,7 @@ def run_loki(supportconfig_path=None, verbose=False):
             "--network",
             network,
             "--publish",
-            "3100:3100",
+            f"{iface}:3100:3100",
             "--name",
             loki_name,
             "--volume",
@@ -58,7 +58,7 @@ def run_loki(supportconfig_path=None, verbose=False):
         "--network",
         network,
         "--publish",
-        "9081:9081",
+        f"{iface}:9081:9081",
         "--detach",
         "--volume",
         f'{config.get_config_file_path("promtail")}:/etc/promtail/config.yml',

--- a/health-check/src/health_check/main.py
+++ b/health-check/src/health_check/main.py
@@ -65,8 +65,17 @@ def cli(ctx: click.Context, supportconfig_path: str, verbose: bool):
     help="Exclude logs after this date (in ISO 8601 format)",
     callback=utils.validate_date,
 )
+@click.option(
+    "-p",
+    "--public",
+    is_flag=True,
+    default=False,
+    help="Expose ports on all interfaces (0.0.0.0)",
+)
 @click.pass_context
-def start(ctx: click.Context, from_datetime: str, to_datetime: str, since: int):
+def start(
+    ctx: click.Context, from_datetime: str, to_datetime: str, since: int, public: bool
+):
     """
     Start execution of Health Check
 
@@ -75,6 +84,7 @@ def start(ctx: click.Context, from_datetime: str, to_datetime: str, since: int):
     """
     verbose: bool = ctx.obj["verbose"]
     supportconfig_path: str | None = ctx.obj["supportconfig_path"]
+    iface = "0.0.0.0" if public else "127.0.0.1"
 
     # Try to resolve an absolute path to the supportconfig
     if supportconfig_path:
@@ -107,9 +117,9 @@ def start(ctx: click.Context, from_datetime: str, to_datetime: str, since: int):
     try:
         with console.status(status=None):
             create_podman_network(verbose=verbose)
-            run_loki(supportconfig_path, verbose)
-            exporter.prepare_exporter(supportconfig_path, verbose)
-            prepare_grafana(from_datetime, to_datetime, verbose)
+            run_loki(supportconfig_path, verbose, iface)
+            exporter.prepare_exporter(supportconfig_path, verbose, iface)
+            prepare_grafana(from_datetime, to_datetime, verbose, iface)
 
         console.print(
             Panel(


### PR DESCRIPTION
With this PR, health-check binds to localhost only by default. Users can still expose the containers to all interfaces by using the `-p` or `--public` flag as such:

```
mgr-health-check -vs uyuni-server/scc_suse_250530_1743/ start -p
```